### PR TITLE
enable NLog logging to VS debug console

### DIFF
--- a/CaliburnTemplate/NLog.config
+++ b/CaliburnTemplate/NLog.config
@@ -12,6 +12,7 @@
   -->
   <variable name="myvar" value="myvalue"/>
 
+  <variable name="ShortLayout" value="${counter} [${date:format=HH\:MM\:ss\.fff}] ${uppercase:${level}} ${message} "/>
   <!-- 
   See https://github.com/nlog/nlog/wiki/Configuration-file 
   for information on customizing logging rules and outputs.
@@ -29,6 +30,8 @@
     <target xsi:type="File" name="f" fileName="${basedir}/logs/${shortdate}.log"
             layout="${longdate} ${uppercase:${level}} ${message}" />
     -->
+    <target name="debug" xsi:type="Debugger" layout="${ShortLayout}" />
+
   </targets>
 
   <rules>
@@ -38,5 +41,7 @@
     Write all events with minimal level of Debug (So Debug, Info, Warn, Error and Fatal, but not Trace)  to "f"
     <logger name="*" minlevel="Debug" writeTo="f" />
     -->
+    <!-- VS console -->
+    <logger name="*" minlevel="Trace" writeTo="debug" />
   </rules>
 </nlog>


### PR DESCRIPTION
I have added the necessary target and rule to enable NLog logging to the VisualStudio debugging console.

Enjoy,
Ly
